### PR TITLE
Fix 2nd dose tooltip wording on homepage vaccination section

### DIFF
--- a/app/templates/components/vaccinations.html
+++ b/app/templates/components/vaccinations.html
@@ -149,7 +149,7 @@
 							<span href="#" class="govuk-link--no-visited-state number-link">
 							{{ secondDosePer.value }}%
 							<span class="tooltiptext govuk-!-font-size-16">
-								Percentage of adults vaccinated (first dose) up to and including {{ secondDosePer.date }}
+								Percentage of adults vaccinated (second dose) up to and including {{ secondDosePer.date }}
 							</span></span>
 							</div>
 						</div>


### PR DESCRIPTION
The percentage fo adults vaccinated for their seccond dose stat has the wrong wording and states it's for first doses when it should be second. This commit corrects the wording.